### PR TITLE
Remove duplicate database creation step in setup guide

### DIFF
--- a/docs/Getting_started/Initial-setup.md
+++ b/docs/Getting_started/Initial-setup.md
@@ -104,10 +104,6 @@ To get started, follow the official guide here:
 9. **Set up the database:**
     - Copy `config/database.yml.example` and rename it to `config/database.yml`.
     - Update database credentials in `config/database.yml` ([Configuration Guide](https://guides.rubyonrails.org/configuring.html#configuring-a-database)).
-    - Create the databases:
-      ```sh
-      rake db:create
-      ```
     - **Prepare your development database:**
         - Using an SQL dump:
           ```sh


### PR DESCRIPTION
The step for creating databases was redundant as it's typically handled automatically in modern Rails workflows. This change streamlines the instructions, reducing potential confusion for users during the initial setup process.